### PR TITLE
Add DSEP contact info for adoption in intro.md

### DIFF
--- a/_build/deploy/README.md
+++ b/_build/deploy/README.md
@@ -6,8 +6,8 @@ prev_page:
   url: /intro
   title: 'Home'
 next_page:
-  url: /deploy/setup_jupyterhub
-  title: 'Deploy your JupyterHub'
+  url: /deploy/choose_cloud
+  title: 'Choose where to deploy your JupyterHub'
 comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /content***"
 ---
 # Deploy Data 8 for your course
@@ -30,5 +30,5 @@ used for.
   host the textbook for the course, and control revisions of all course
   materials. It's also where you can host your course template online.
 * [Kubernetes](https://kubernetes.io/) (optional, only if your course is
-  > around 60 students) is used to orchestrate the cloud
+  around 60 students) is used to orchestrate the cloud
   resources that serve user sessions.

--- a/_build/deploy/setup_jupyterhub.md
+++ b/_build/deploy/setup_jupyterhub.md
@@ -3,8 +3,8 @@ redirect_from:
   - "deploy/setup-jupyterhub"
 title: 'Deploy your JupyterHub'
 prev_page:
-  url: /deploy/README
-  title: 'Deploying Data 8'
+  url: /deploy/choose_cloud
+  title: 'Choose where to deploy your JupyterHub'
 next_page:
   url: /deploy/customize_hub_environment
   title: 'Customize the JupyterHub environment for Data 8'
@@ -18,13 +18,17 @@ own workspaces so they can interact with course material. This section
 covers how to set up a JupyterHub that runs the environment needed for
 Data 8.
 
-## Deploying JupyterHub in the cloud
+## What distribution of JupyterHub should I use?
+
+JupyterHub has a few "distributions" that make it easy to set up on a particular
+kind of cloud infrastructure. Which one you choose will depend on your use-case.
+This section provides some information to help you decide.
 
 There are two recommended methods for running a JupyterHub for your course.
 Which one you choose depends on the size and computational demands for the course.
 To run the code in Data 8, students do not need high-powered environments.
 
-Once you've either of the sections below, you should have a JupyterHub available at a
+Once you've followed either of the sections below, you should have a JupyterHub available at a
 public address. The remainder of this guide will focus on customizing the
 environment that this JupyterHub serves in order to work with the Data 8
 course materials.
@@ -32,7 +36,7 @@ course materials.
 ### Deploy JupyterHub on a single VM (<= 50 students)
 
 For courses of 50 or less students we recommend
-[*The Littlest JupyterHub**](https://the-littlest-jupyterhub.readthedocs.io/en/latest/),
+[**The Littlest JupyterHub**](https://the-littlest-jupyterhub.readthedocs.io/en/latest/),
 a short guide for deploying JupyterHub on a virtual machine (VM).
 Follow the instructions on the link above to deploy a JupyterHub with a publicly-accessible
 IP address.

--- a/_build/intro.md
+++ b/_build/intro.md
@@ -73,3 +73,8 @@ data analytics pedagogy. Here are a few notable resources:
 * [The Jupyter for Education Handbook](https://jupyter4edu.github.io/jupyter-edu-book/)
   is a more general resource for teaching using tools in the Jupyter ecosystem, and has several
   best-practices and tips.
+
+## Contacting Us
+
+If you woud like to learn more about any of the tools used in Data 8 or are interested in deploying your own data 8 course, 
+please fill out our [Data 8 Instructor Interest form](https://forms.gle/maRqsceCvTNnqQ3w9) or shoot us an email at `ds-help@berkeley.edu`.

--- a/_build/tech/considerations.md
+++ b/_build/tech/considerations.md
@@ -16,9 +16,73 @@ doing non-trivial computational work is a big technical challenge. This page det
 the guiding principles and priorities that the Data 8 team considered in solving these problems with
 technology.
 
+## Open source strategy
+
+A core goal of the Data 8 project is to use an entirely open stack to use in our course. We
+chose this approach for a few main reasons:
+
+* **Using an open stack gives us freedom to deploy Data 8 anywhere.** By running on entirely open
+  tools we can ensure that Data 8 is not tied to a specific proprietary tool, or a single
+  vendor's offering. We believe that this flexibility and choice benefits us (even if it
+  occasionally means passing on vendor-specific options that would save us time in the short-term).
+* **Using an open stack means we don't have to re-invent the wheel.** One of the benefits
+  of using open tools is that many useful tools *already exist* and we would rather piggy-back
+  off of the work of others than re-invent the wheel ourselves. For this reason, we prefer to
+  find open source tools and leverage them in data 8, rather than start from scratch.
+* **Using an open stack lets us contribute back.** Finally, Data 8 also uses its resources to
+  *contribute back* to the open source projects that we utilize. For example, many improvements
+  to JupyterHub, Jupyter Notebooks, and JupyterLab have been made by the team working on
+  Data 8. As many of these projects are already developed by universities and other organizations
+  dedicated to the public good, this is an opportunity for us to give back to the community
+  that makes courses like data 8 possible.
+
+So what do we mean when we say "open stack"? Open source tools are inter-woven with the Data 8
+mission. We'll cover several of the main pieces of this stack in the sections below.
+
+### Python - an open language
+
+Data 8 uses Python for all of its course material. This is because its both extremely popular
+as well as open source. Being an open source language means that anybody can use the language,
+contribute to it, or even modify it if they wish. The language isn't "owned" by anybody, which
+we believe is an important foundation to use for introducing students to data science.
+
+### The Scipy stack - an open source ecosystem
+
+On top of the Python language is a thriving community of libraries and tools for scientific
+computing. These are largely developed and driven by an open community of developers, many
+of whom are researchers and educators at universities. Utilizing an open stack allows us to
+leverage the combined expertise of thousands of members of the open source community. For
+example, the `datascience` package utilizes functions in NumPy (a tool for linear algebra),
+SciPy (a set of tools for scientific tasks), Pandas (a tool for dealing with tabular data),
+and Matplotlib (a tool for visualization).
+
+### Jupyter Notebooks - an open source interface
+
+The interface that all students use is called the Jupyter Notebook interface. Jupyter Notebooks
+are an open source tool built by the Jupyter Project, another open project. They are a de-facto
+standard across both academic research as well as industry. We wanted to use notebooks both because
+they were quite useful for interactive computing and as a tool for communication, but also because
+they are free, usable by anybody, developed by an open community, and used across many institutions
+and organizations.
+
+### JupyterHub and Kubernetes - open infrastructure for the cloud
+
+Finally, all of the course infrastructure that Data 8 uses runs on JupyterHub and Kubernetes. These
+are both open source projects for managing user sessions as well as orchestrating computational
+resources in the cloud. We decided to run our course on open infrastructure because it gives us
+the freedom to run Data 8 on any cloud provider, and lessens the likelihood that we will become
+dependent on a single cloud vendor to run the course. It also allowed us to improve these tools,
+allowing other organizations to deploy JupyterHub for teaching Data 8 on whatever cloud resources
+they'd prefer. For example JupyterHub runs on both large, scalable cloud infrastructure like
+Kubernetes, but also on much smaller-scale infrastructure such as a single machine, which gives
+others more flexibility in how and where they want to run their data 8 infrastructure.
+
 ## Major hurdles
+
+The following are major hurdles that we encountered when running and designing Data 8.
+
 * **Standardizing environments is hard**. Anyone who has taught a bootcamp knows the pain involved in getting a room of 20 students with the same functioning environment. Data 8 has nearly two orders of magnitude more students. For an introduction class, requiring students to set up their own environment is a huge distraction and dis-equalizer.
-* **Avoiding cloud lock-in**. There are many options for interacting with the cloud, but most are bespoke interfaces that pair with a *product* you eventually pay for (e.g. https://aws.amazon.com/education/). We didn't want Data 8 to depend on a specific provider.
+* **Avoiding cloud lock-in**. There are many options for interacting with the cloud, but most are bespoke interfaces that pair with a *product* you eventually pay for (e.g. https://aws.amazon.com/education/). We didn't want Data 8 to depend on a specific provider, interface, or other set of packages.
 * **Be platform-agnostic**. Most data analytics classes have similar problems (e.g., managing a kernel in the cloud) even if the tools they use are quite different (e.g., R vs. Python). Data 8 intentionally used tools that were platform-agnostic (e.g., tools in the Jupyter project) to make course infrastructure useful for many different topics.
 * **Use open-source tools.** While there are many proprietary options for managing classrooms and technical resources, they are not as generalizable and serve as hurdles to wider adoption of material.
 * **Development/Operations skills are not common**. Scaling class to large size requires technical + personnel that aren't always common in academia

--- a/content/intro.md
+++ b/content/intro.md
@@ -66,5 +66,5 @@ data analytics pedagogy. Here are a few notable resources:
 
 ## Contacting Us
 
-If you woud like to learn more about any of the tools used in Data 8 or are interested in deploying your own data 8 course, 
+If you would like to learn more about any of the tools used in Data 8 or are interested in deploying your own data 8 course, 
 please fill out our [Data 8 Instructor Interest form](https://forms.gle/maRqsceCvTNnqQ3w9) or shoot us an email at `ds-help@berkeley.edu`.

--- a/content/intro.md
+++ b/content/intro.md
@@ -63,3 +63,8 @@ data analytics pedagogy. Here are a few notable resources:
 * [The Jupyter for Education Handbook](https://jupyter4edu.github.io/jupyter-edu-book/)
   is a more general resource for teaching using tools in the Jupyter ecosystem, and has several
   best-practices and tips.
+
+## Contacting Us
+
+If you woud like to learn more about any of the tools used in Data 8 or are interested in deploying your own data 8 course, 
+please fill out our [Data 8 Instructor Interest form](https://forms.gle/maRqsceCvTNnqQ3w9) or shoot us an email at `ds-help@berkeley.edu`.


### PR DESCRIPTION
Currently there does not appear to be any contact links or information on `intro.md`. Notably, the intro even mentions "if you’d like to modify the textbook’s content for your own course, please shoot us an email!", but there is no email address. 

This PR adds a new "Contact Us" subsection in the intro with the external adoption email address `ds-help@berkeley.edu`, along with the [data 8 instructor interest form](https://forms.gle/maRqsceCvTNnqQ3w9). 
