### PR TITLE
Add jupyterhub/intro.md and faq.md file for v2

### DIFF
--- a/content/v2/tech/faq.md
+++ b/content/v2/tech/faq.md
@@ -1,0 +1,25 @@
+# Frequently Asked Questions (FAQ)
+
+The following section contains some frequently asked questions around deploying
+Data 8 with JupyterHub. If you have a question that isn't answered, feel free
+to [open an issue on the Z2D8 github repository](https://github.com/data-8/zero-to-data-8/issues).
+
+## How can I deploy a JupyterHub on hardware that isn't listed in this guide?
+
+These guides focus on deploying JupyterHub on large cloud providers such as
+Microsoft, Google, and Amazon. However, many organizations prefer to deploy on
+something other than this (e.g. their own local hardware).
+
+You can deploy a JupyterHub on any hardware, though it must run Kubernetes. 
+Setting up Kubernetes is not trivial, so we recommend cloud providers 
+as they simplify this process significantly. If there's a specific provider
+or setup that you *think* should be officially documented, please reach out and we can discuss!
+
+## Where can I find the guide to deploy JupyterHub?
+
+For courses of 50 or less students we recommend
+[**The Littlest JupyterHub**](https://the-littlest-jupyterhub.readthedocs.io/en/latest/) guide.
+
+For courses of more than 50 students we recommend the
+[**Zero to JupyterHub for Kubernetes**](https://zero-to-jupyterhub.readthedocs.io/en/latest/) guide.
+

--- a/content/v2/tech/jupyterhub/intro.md
+++ b/content/v2/tech/jupyterhub/intro.md
@@ -2,6 +2,8 @@
 
 This section describes the process of configuring and deploying your own Jupyterhub. It gives an overview of how to make important design decisions, such as where to deploy your hub and what Hub size is needed. 
 
+[**JupyterHub**](https://zero-to-jupyterhub.readthedocs.io/en/latest/) is a multi-user Hub that allows students to interact with their own computing environment. It makes it easy to spawn and manage multiple instances of a Jupyter notebook.
+
 ## Why JupyterHub?
 
 

--- a/content/v2/tech/jupyterhub/intro.md
+++ b/content/v2/tech/jupyterhub/intro.md
@@ -15,7 +15,6 @@ the freedom to run Data 8 on any cloud provider, and lessens the likelihood of b
 dependent on a single cloud vendor to run the course. It also allowed us to improve these tools,
 allowing other organizations to deploy JupyterHub for teaching Data 8 on whatever cloud resources
 they'd prefer. For example JupyterHub runs on both large, scalable cloud infrastructure like
-Kubernetes, but also on much smaller-scale infrastructure such as a single machine, which gives
+Kubernetes, but also on much smaller-scale infrastructure without Kubernetes, such as a single machine, which gives
 others more flexibility in how and where they want to run their Data 8 infrastructure.
-
 

--- a/content/v2/tech/jupyterhub/intro.md
+++ b/content/v2/tech/jupyterhub/intro.md
@@ -6,8 +6,7 @@ This section describes the process of configuring and deploying your own Jupyter
 
 ## Why JupyterHub?
 
-
-Data 8 operates on a scale and level of complexity that required several technological improvements to our current teaching toolset. The Data 8 team worked closely with various open-source projects in order to contribute to tools that are broadly useful.
+Data 8 started with 60 students in Fall 2015, and now has 1350 students as of Spring 2020. The course operates on a scale and level of complexity that required several technological improvements to our current teaching toolset. The Data 8 team worked closely with various open-source projects in order to contribute to tools that are broadly useful.
 
 All of the course infrastructure that Data 8 uses runs on JupyterHub and Kubernetes. These
 are both open source projects for managing user sessions and orchestrating computational

--- a/content/v2/tech/jupyterhub/intro.md
+++ b/content/v2/tech/jupyterhub/intro.md
@@ -4,7 +4,6 @@ This section describes the process of configuring and deploying your own Jupyter
 
 ## Why JupyterHub?
 
-[**JupyterHub**](https://zero-to-jupyterhub.readthedocs.io/en/latest/) is a multi-user Hub that allows students to interact with their own computing environment. It makes it easy to spawn and manage multiple instances of a Jupyter notebook.
 
 Data 8 operates on a scale and level of complexity that required several technological improvements to our current teaching toolset. The Data 8 team worked closely with various open-source projects in order to contribute to tools that are broadly useful.
 
@@ -17,4 +16,3 @@ allowing other organizations to deploy JupyterHub for teaching Data 8 on whateve
 they'd prefer. For example JupyterHub runs on both large, scalable cloud infrastructure like
 Kubernetes, but also on much smaller-scale infrastructure without Kubernetes, such as a single machine, which gives
 others more flexibility in how and where they want to run their Data 8 infrastructure.
-

--- a/content/v2/tech/jupyterhub/intro.md
+++ b/content/v2/tech/jupyterhub/intro.md
@@ -1,0 +1,21 @@
+# JupyterHub Overview
+
+This section describes the process of configuring and deploying your own Jupyterhub. It gives an overview of how to make important design decisions, such as where to deploy your hub and what Hub size is needed. 
+
+## Why JupyterHub?
+
+[**JupyterHub**](https://zero-to-jupyterhub.readthedocs.io/en/latest/) is a multi-user Hub that allows students to interact with their own computing environment. It makes it easy to spawn and manage multiple instances of a Jupyter notebook.
+
+Data 8 operates on a scale and level of complexity that required several technological improvements to our current teaching toolset. The Data 8 team worked closely with various open-source projects in order to contribute to tools that are broadly useful.
+
+All of the course infrastructure that Data 8 uses runs on JupyterHub and Kubernetes. These
+are both open source projects for managing user sessions and orchestrating computational
+resources in the cloud. We decided to run our course on an open infrastructure because it gives us
+the freedom to run Data 8 on any cloud provider, and lessens the likelihood of becoming
+dependent on a single cloud vendor to run the course. It also allowed us to improve these tools,
+allowing other organizations to deploy JupyterHub for teaching Data 8 on whatever cloud resources
+they'd prefer. For example JupyterHub runs on both large, scalable cloud infrastructure like
+Kubernetes, but also on much smaller-scale infrastructure such as a single machine, which gives
+others more flexibility in how and where they want to run their Data 8 infrastructure.
+
+


### PR DESCRIPTION
This PR adds an intro.md file for the JupyterHub section. It gives an overview of JupyterHub and why it is used. Some of the information on the page is pulled from the 'Technology stack' and 'General Technical Considerations' pages in v1. 

The second commit adds a FAQ.md file for the technology book. I removed some questions that applied to pedagogy and edited some phrasing.